### PR TITLE
Add logging and more informative output from run.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ the post to have a specific date, prepend it to the filename. For example:
 If you do not specify a date in the filename, quark will rename the file with
 today's date. The posts will be sorted (descending) by date.
 
+### Misc:
+To disable logging:
+
+`python run.py --logging=none` 
+
 ### To Do:
 
 * Properly sort posts within a single day.

--- a/run.py
+++ b/run.py
@@ -3,6 +3,8 @@ from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
 from create_blog import app
 from ConfigParser import SafeConfigParser
+import tornado.options
+tornado.options.parse_command_line()
 
 parser = SafeConfigParser()
 parser.read('config.txt')
@@ -11,4 +13,9 @@ lport = parser.get('config', 'PORT')
 
 http_server = HTTPServer(WSGIContainer(app))
 http_server.listen(lport)
-IOLoop.instance().start()
+print('Server running on http://localhost:' + lport)
+try:
+    IOLoop.instance().start()
+except:
+    print('\nExiting...')
+    IOLoop.instance().stop()


### PR DESCRIPTION
- Enable tornado logging to show requests output at command prompt when running run.py.
- Print a message showing the server is running and on which url
- Gracefully handle stopping the server with CTRL+C